### PR TITLE
trim Dockerfile

### DIFF
--- a/_course_files/envoy_demo/Dockerfile
+++ b/_course_files/envoy_demo/Dockerfile
@@ -1,4 +1,3 @@
 FROM envoyproxy/envoy:v1.11.2
-RUN apt-get update
 COPY config.yaml /etc/envoy.yaml
 CMD /usr/local/bin/envoy -c /etc/envoy.yaml


### PR DESCRIPTION
Since we are not running "apt-get update -y" or "apt-get dist-upgrade -y" in the Dockerfile, there is no need to keep the "apt-get update" line also.