### PR TITLE
update kiali CRD for apiextensions.k8s.io/v1 workaround

### DIFF
--- a/_course_files/8 Customization/init-addons.yaml
+++ b/_course_files/8 Customization/init-addons.yaml
@@ -1,4 +1,4 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: monitoringdashboards.monitoring.kiali.io
@@ -14,4 +14,8 @@ spec:
   - name: v1alpha1
     served: true
     storage: true
+    schema:
+      openAPIV3Schema:
+        type: object
+        x-kubernetes-preserve-unknown-fields: true
 ...


### PR DESCRIPTION
Thank you for the great hands-on :pray:

I'm using Kubernetes v1.22.1 and `apiextensions.k8s.io/v1beta1` API version of CustomResourceDefinition is no longer served as of v1.22 ([Deprecated API Migration Guide | Kubernetes](https://kubernetes.io/docs/reference/using-api/deprecation-guide/#customresourcedefinition-v122))
So I had the error:
```
~/git/istio-fleetman/_course_files/8 Customization$ k apply -f init-addons.yaml
error: unable to recognize "init-addons.yaml": no matches for kind "CustomResourceDefinition" in version "apiextensions.k8s.io/v1beta1"
```

This PR adapts Kiali CRD to `apiextensions.k8s.io/v1` based on [kiali-operator/manifests/kiali-community/1.36.0/manifests/kiali.monitoringdashboards.crd.yaml](https://github.com/kiali/kiali-operator/blob/0d82fdfbed750f240bf501b4844abd95b0b7e53c/manifests/kiali-community/1.36.0/manifests/kiali.monitoringdashboards.crd.yaml). But I think it's a workaround.

1.37.0+ version of Kiali, it looks there is an another CRD resource like [kiali-operator/manifests/kiali-community/1.37.0/manifests/kiali.crd.yaml](https://github.com/kiali/kiali-operator/blob/master/manifests/kiali-community/1.37.0/manifests/kiali.crd.yaml)
