### PR TITLE
Embed Jaeger Tracing in Kiali UI

### DIFF
--- a/_course_files/1 Telemetry/2-istio-minikube.yaml
+++ b/_course_files/1 Telemetry/2-istio-minikube.yaml
@@ -5238,6 +5238,9 @@ data:
     external_services:
       custom_dashboards:
         enabled: true
+      tracing:
+        in_cluster_url: 'http://tracing.istio-system:80/jaeger'
+        use_grpc: false
     identity:
       cert_file: ""
       private_key_file: ""


### PR DESCRIPTION
Kilai enables this by default, but since our demo instance does not enable theGRPC query port, and exposes http on alternate port, it is disabled.

This patch just changes URL to port 80, and disable grpc (query, not collector)

## Demo

With that 3 line change, the `traces` tab is enabled on services, and includes spans.

![Screen Shot 2022-10-19 at 2 31 05 PM](https://user-images.githubusercontent.com/5262154/196775510-a5d7a053-26ed-4d21-b848-730675e9cf3f.png)
![Screen Shot 2022-10-19 at 2 33 14 PM](https://user-images.githubusercontent.com/5262154/196775564-7f005733-f873-47c1-ac01-562db0fa1291.png)


## NOTE

I am still early in lessons and assume this change will need to be replicated across courses.